### PR TITLE
Replace pkg_resources with importlib.metadata; bump minor version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plaster_yaml"
-version = "0.1.2"
+version = "0.2.0"
 description = "A plaster plugin to configure pyramid app with Yaml"
 readme = "README.md"
 authors = ["Guillaume Gauvrit <guillaume@gauvr.it>"]
@@ -8,9 +8,12 @@ include = ["CHANGELOG.md"]
 license = "BSD-derived"
 
 [tool.poetry.dependencies]
+# See: https://pypi.org/project/backports.entry-points-selectable
+importlib_metadata = { version = ">=3.6", python = "<3.10" }
 python = "^3.7"
 plaster = "^1.0"
-PyYAML = "^5.4.1"
+# Upgraded PyYAML from ^5.4 due to: https://github.com/yaml/pyyaml/issues/601
+PyYAML = "^6.0.1"
 
 [tool.poetry.dev-dependencies]
 black = "^21.4b0"

--- a/src/plaster_yaml/__init__.py
+++ b/src/plaster_yaml/__init__.py
@@ -1,5 +1,15 @@
-import pkg_resources
+import sys
+
+if sys.version_info < (3, 10):
+    import importlib_metadata
+
+    class importlib:
+        pass
+
+    setattr(importlib, "metadata", importlib_metadata)
+else:
+    import importlib.metadata
 
 from .loader import Loader  # noqa
 
-__version__ = pkg_resources.get_distribution("plaster-yaml").version
+__version__ = importlib.metadata.version("plaster-yaml")

--- a/src/plaster_yaml/loader.py
+++ b/src/plaster_yaml/loader.py
@@ -3,7 +3,18 @@ import pathlib
 from logging.config import dictConfig
 from typing import Callable
 
-import pkg_resources
+import sys
+
+if sys.version_info < (3, 10):
+    import importlib_metadata
+
+    class importlib:
+        pass
+
+    setattr(importlib, "metadata", importlib_metadata)
+else:
+    import importlib.metadata
+
 import plaster
 import yaml
 
@@ -39,8 +50,8 @@ def resolve_use(use: str, entrypoint: str) -> Callable:
     if scheme != "egg":
         raise ValueError(f"{use}: unsupported scheme {scheme}")
 
-    distribution = pkg_resources.get_distribution(pkg)
-    runner = distribution.get_entry_info(entrypoint, name)
+    eps = importlib.metadata.entry_points(group=entrypoint, name=name)
+    (runner,) = [ep for ep in eps if ep.module == pkg]
     return runner.load()
 
 

--- a/src/plaster_yaml/loader.py
+++ b/src/plaster_yaml/loader.py
@@ -51,7 +51,7 @@ def resolve_use(use: str, entrypoint: str) -> Callable:
         raise ValueError(f"{use}: unsupported scheme {scheme}")
 
     eps = importlib.metadata.entry_points(group=entrypoint, name=name)
-    (runner,) = [ep for ep in eps if ep.module == pkg]
+    (runner,) = [ep for ep in eps if ep.module.split(".")[0] == pkg]
     return runner.load()
 
 

--- a/tests/test_plaster_yaml.py
+++ b/tests/test_plaster_yaml.py
@@ -3,7 +3,6 @@ from unittest.mock import call, patch
 
 import pytest
 from gunicorn.app.pasterapp import serve as gunicorn_serve_paste
-from pkg_resources import DistributionNotFound
 from waitress import serve_paste as waitress_serve_paste
 
 from plaster_yaml.loader import resolve_use


### PR DESCRIPTION
Hi,

Thanks for this package.

pkg_resources is depreciated.  importlib.metadata replaces it.

I ran into PyYAML issue #601: https://github.com/yaml/pyyaml/issues/601
The 5.4 .* releases all have the problem, so I bumped the required PyYAML version.  PyYAML claims to support Python >=3.6, so that should not cause problems with your supported Python version.  I can't say if this change would cause any other issues.

I can't say I know what I'm doing when it comes to python packaging.  I'm also not sure that I properly ran the regression tests.  I did run them and they passed, but only on Debian 12 (bookworm) with Python 3.11 (in a virtual environment containing the latest poetry and other tooling).  (You see two commits here because I goofed the regression test run, at first.)

It is probably a good idea to bump the pyramid-helloworld required package version from 0.1.2.  The current version is 1.0.0, and I sent in a PR that removes pkg_resources and bumps the pyramid-helloworld version to 1.1.0.  In any case, leaving the required pyramid-helloworld version untouched in this package avoids some sort of reflexive mutual conflict which might prevent both from running their tests.

Notes on backported standard library modules:

I like to conditionally import backported standard library modules.  I like to see the version number in the code so the version number is explicit, and in an obvious place.  That way it is clear when it is time to remove the conditional import and just use the standard library.

I find that creating a class to act as the top-level module in the module path, when the backported library is not top-level, helps with mocks when unit testing.