### PR TITLE
Fix crash when non-existant sections are requested

### DIFF
--- a/src/plaster_yaml/loader.py
+++ b/src/plaster_yaml/loader.py
@@ -71,6 +71,9 @@ class Loader(plaster.ILoader):
         if defaults is not None:
             result.update(defaults)
 
+        if section not in self._conf:
+            return {}
+        
         settings = self._conf[section].copy()
 
         for key, val in settings.items():


### PR DESCRIPTION
Hi,

I tried out using plaster-yaml with a setup.py config and found a problem.  Whether setup.py has anything to do with the bug is questionable. 

The fix, on the surface anyway, seems to be the right thing to do. Having said that, I really don't understand everything involved.  I based the fix on plaster-pastedeploy.  Take a look at: https://github.com/Pylons/plaster_pastedeploy/blob/b92a7fb106643b9bc77b6b21150523bc60ac1179/src/plaster_pastedeploy/__init__.py#L69

Here is how to reproduce the problem:
```
python3 -m venv venv
./venv/bin/pip install --upgrade pip setuptools
./venv/bin/pip install cookiecutter
./venv/bin/cookiecutter --no-input gh:Pylons/pyramid-cookiecutter-starter
 cd pyramid_scaffold/
# Put the setup.py and config.yaml files in the attached bugfiles.zip file
# into the current directory.
./venv/bin/pip install -e .
../venv/bin/pserve config.yaml
```
Attached: [bugfiles.zip](https://github.com/mardiros/plaster-yaml/files/14813282/bugfiles.zip)
Debian 12.5
Python 3.11.2