### PR TITLE
Fix plaster-yaml setuptools-related entrypoint examples so they work

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ follows:
 [project.entry-points.'paste.app_factory']
 main = '<my_app>:main']
 [project.entry-points.'plaster.loader_factory']
-yaml = 'plaster_yaml:Loader'
+'file+yaml' = 'plaster_yaml:Loader'
 ```
 
 ### With `setup.py`
@@ -95,7 +95,7 @@ setup(
     ...,
     entry_points={
      'paste.app_factory': ['main = <my_app>:main'],
-     'plaster.loader_factory': ['yaml = plaster_yaml:Loader'],
+     'plaster.loader_factory': ['file+yaml = plaster_yaml:Loader'],
      ...
     },
 )


### PR DESCRIPTION
The entrypoints in the README related to setuptools don't work.  I don't know if they should, or not.

In any case, this patch updates the entrypoints to be consistent with the poetry entrypoints.

(I tried out the setup.py version of the entrypoint in this patch in PR #7 , and it worked -- after the patch in PR #7 was applied.)
