### PR TITLE
get_sections() is supposed to return a list of all sections

### DIFF
--- a/src/plaster_yaml/loader.py
+++ b/src/plaster_yaml/loader.py
@@ -58,7 +58,7 @@ class Loader(plaster.ILoader):
             self._conf = yaml.safe_load(stream)
 
     def get_sections(self):
-        return ["app"]
+        return list(self._conf.keys())
 
     def get_settings(self, section=None, defaults=None):
         # fallback to the fragment from config_uri if no section is given

--- a/tests/test_plaster_yaml.py
+++ b/tests/test_plaster_yaml.py
@@ -30,7 +30,7 @@ def test_defaults(loader):
 
 @pytest.mark.usefixtures("loader")
 def test_get_sections(loader):
-    assert loader.get_sections() == ["app"]
+    assert loader.get_sections() == ["app", "server", "logging"]
 
 
 @pytest.mark.usefixtures("loader")


### PR DESCRIPTION
loader.get_sections() is supposed to return a list of all sections.

A "big bug".

See [the get_sections() docs](https://docs.pylonsproject.org/projects/plaster/en/latest/api.html#plaster.ILoader.get_sections) or look at [the plaster-pastedeploy code](https://github.com/Pylons/plaster_pastedeploy/blob/b92a7fb106643b9bc77b6b21150523bc60ac1179/src/plaster_pastedeploy/__init__.py#L35), a wrapper around the standard library's configparser.ConfigParser().