### PR TITLE
Update readme that reference plugin activation that is made by the plugin itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,24 @@ https://docs.pylonsproject.org/projects/plaster/en/latest/) loader
 interface, accept YAML configuration sources.
 
 By default, Pyramid (etc.) uses the PasteDeploy (.ini) file format for
-its configuration.  With the `plaster-yaml` plugin, Pyramid
+its configuration. PasteDeploy has become obsolete and has been replace
+by [plaster](https://docs.pylonsproject.org/projects/plaster/) and accept
+plugins to write more file format.
+
+With the `plaster-yaml` plugin, Pyramid
 applications can also be configured with a YAML configuration file.
 
 For example, one application can be run either of these ways:
 
-```
-pserve development.yaml
-pserve development.ini
-```
-
 Because JSON is a subset of YAML `plaster-yaml` also supports JSON
 configuration files.  The "With `pyproject.toml` and a `setuptools`
 `build` back-end" section below contains a JSON example.
+
+```bash
+pserve development.yaml
+pserve development.json
+pserve development.ini
+```
 
 ## Installation
 
@@ -44,41 +49,12 @@ pip install plaster-yaml
 
 ## Usage
 
-The `plaster-yaml` plugin must be "registered".  This is done by
-configuring a Python package "entry point" using the packaging tool of
-your choice.  How this is done depends on the packaging tool.
-Examples are given below.
-
-It is the entry point's name, as will be clear in the examples, that
-"connects" the filename extension of a configuration file to the
-loader able to parse it.  While it is not necessary to know the
-details, here are the basic concepts: The entry point's name is a
-[config_uri](
-https://docs.pylonsproject.org/projects/plaster/en/latest/glossary.html#term-config-uri).
-The scheme is that part of the URI to the left of the colon, and is
-itself divisible.  One of the scheme's components is matched with the
-filename extension to select the correct loader.
-
-When developing, using an [editable](
-https://setuptools.pypa.io/en/latest/userguide/development_mode.html)
-install that executes your unpackaged code, after changing your
-package's configuration your packaging tool must be run in order to
-finalize the registration.  Examples are given below.
-
-No special steps must be taken after configuring a entry point and
-(correctly) packaging your project.  The `plaster-yaml` plugin is
-registered when your project's package is installed.
-
-NOTE:\
-All of the examples given below show not only how the one entry point
-required to use `plaster-yaml` is configured, but also show how to
-configure the entry point that makes your application into a WSGI,
-web-based, application.  The WSGI entry point is always required for
-Pyramid web applications.
+WSGI application that use plaster have to register an [entry point](https://packaging.python.org/en/latest/specifications/entry-points/),
+from a ``paste.app_factory``.
 
 ## With poetry
 
-Plugin registration is configured in your `pyproject.toml`, as
+App registration is configured in your `pyproject.toml`, as
 follows:
 
 ```
@@ -87,12 +63,12 @@ main = "<PATH_TO_MODULE_CONTAINING_MAIN>:main"
 
 ```
 
-When developing, run `poetry install` to register your plugin after
+When developing, run `poetry install` to register your application after
 adding the above to your `pyproject.toml`.
 
 ## With setuptools
 
-When developing, run `pip install -e .` to register your plugin after
+When developing, run `pip install -e .` to register your application after
 using either of approaches below.
 
 ### With `pyproject.toml` and a `setuptools` `build` back-end
@@ -113,9 +89,6 @@ in additional to YAML and .ini config files:
 ```
 [project.entry-points.'paste.app_factory']
 main = '<my_app>:main']
-
-[project.entry-points.'plaster.loader_factory']
-'file+json' = 'plaster_yaml:Loader'
 ```
 
 ### With `setup.py`
@@ -125,7 +98,7 @@ This method is generally obsolete, but it can be used when the
 method must be used when the deprecated `python setup.py ...`
 command is the package building method.
 
-Plugin registration may be configured in your `setup.py`, as
+Application registration may be configured in your `setup.py`, as
 follows:
 
 ```
@@ -137,18 +110,6 @@ setup(
     },
 )
 ```
-
-## Troubleshooting
-
-The following exception means that you did not successfully register
-the `plaster-yaml` plugin:
-
-```
-plaster.exceptions.LoaderNotFound: Could not find a matching loader for the scheme "file+yaml", protocol "wsgi".
-```
-
-Read the relevant "Usage" sub-section, above, to find out how to
-register it properly.
 
 ## Appendix: A sample YAML config file for Pyramid
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ PyYAML = "^6.0.1"
 
 [tool.poetry.plugins."plaster.loader_factory"]
 "file+yaml" = "plaster_yaml:Loader"
+"file+yml" = "plaster_yaml:Loader"
+"file+json" = "plaster_yaml:Loader"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
Fix #23


also activate the plugin for file format `.yml` or `.json`